### PR TITLE
fix: change Stork DC to Stratos DC

### DIFF
--- a/_docs/projects/nautilus.md
+++ b/_docs/projects/nautilus.md
@@ -51,6 +51,6 @@ The Nautilus is a three-tier application and is deployed in the Stratos Datacent
 |ststor01        |172.16.238.15  | ststor01.stratos.xfusioncorp.com|natasha |Bl@kW| Nautilus Storage Server
 |stbkp01         | 172.16.238.16 | stbkp01.stratos.xfusioncorp.com |clint |H@wk3y3| Nautilus Backup Server
 |stmail01        | 172.16.238.17 | stmail01.stratos.xfusioncorp.com|groot |Gr00T123| Nautilus Mail Server
-|jump_host       | Dynamic       | jump_host.stratos.xfusioncorp.com |thor|mjolnir123|Jump Server to Access Stork DC
+|jump_host       | Dynamic       | jump_host.stratos.xfusioncorp.com |thor|mjolnir123|Jump Server to Access Stratos DC
 |jenkins         | 172.16.238.19 | jenkins.stratos.xfusioncorp.com |jenkins|j@rv!s|Jenkins Server for CI/CD
  


### PR DESCRIPTION
based on the [architecture](https://lucid.app/lucidchart/58e22de2-c446-4b49-ae0f-db79a3318e97/view?page=0_0#), it should be called Stratos DC